### PR TITLE
[WIP] Use the new activity result APIs and retire the AutoResolveHelper

### DIFF
--- a/java/app/src/main/res/layout/activity_checkout.xml
+++ b/java/app/src/main/res/layout/activity_checkout.xml
@@ -19,7 +19,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#fff"
     android:fillViewport="true"
     tools:context="com.google.android.gms.samples.wallet.activity.CheckoutActivity">
 
@@ -43,7 +42,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="15dp"
             android:text="[Placeholder] Men's Tech Shell Full-Zip"
-            android:textColor="#333333"
+            android:textColor="?android:textColorPrimary"
             android:textSize="20sp"
             android:textStyle="bold" />
 
@@ -53,14 +52,14 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:text="$50.20"
-            android:textColor="#777777" />
+            android:textColor="?android:textColorSecondary" />
 
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="15dp"
             android:text="@string/checkout_item_description"
-            android:textColor="#333333"
+            android:textColor="?android:textColorPrimary"
             android:textStyle="bold" />
 
         <TextView
@@ -70,8 +69,12 @@
             android:layout_marginTop="5dp"
             android:layout_marginBottom="15dp"
             android:text="[Placeholder] A versatile full-zip that you can wear all day long and even..."
-            android:textColor="#777777" />
+            android:textColor="?android:textColorSecondary" />
 
+        <!--
+            TODO Check out Google Pay's brand guidelines to discover all button types and styles:
+            https://developers.google.com/pay/api/android/guides/brand-guidelines#assets
+        -->
         <include
             android:id="@+id/googlePayButton"
             layout="@layout/buy_with_googlepay_button"

--- a/java/app/src/main/res/values/dimens.xml
+++ b/java/app/src/main/res/values/dimens.xml
@@ -22,7 +22,7 @@
     <dimen name="margin_xlarge">30dp</dimen>
 
     <dimen name="buy_button_width">300dp</dimen>
-    <dimen name="buy_button_height">48sp</dimen>
+    <dimen name="buy_button_height">48dp</dimen>
     <dimen name="buy_button_min_width">200dp</dimen>
 
     <!-- Notifications -->

--- a/kotlin/app/src/main/res/layout/activity_checkout.xml
+++ b/kotlin/app/src/main/res/layout/activity_checkout.xml
@@ -19,7 +19,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="#fff"
     android:fillViewport="true"
     tools:context="com.google.android.gms.samples.wallet.activity.CheckoutActivity">
 
@@ -43,7 +42,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="15dp"
             android:text="Men's Tech Shell Full-Zip"
-            android:textColor="#333333"
+            android:textColor="?android:textColorPrimary"
             android:textSize="20sp"
             android:textStyle="bold" />
 
@@ -52,7 +51,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
-            android:textColor="#777777"
+            android:textColor="?android:textColorSecondary"
             android:text="$50.20"/>
 
         <TextView
@@ -60,7 +59,7 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="15dp"
             android:text="Description"
-            android:textColor="#333333"
+            android:textColor="?android:textColorPrimary"
             android:textStyle="bold" />
 
         <TextView
@@ -69,9 +68,13 @@
             android:layout_height="wrap_content"
             android:layout_marginTop="5dp"
             android:layout_marginBottom="15dp"
-            android:textColor="#777777"
+            android:textColor="?android:textColorSecondary"
             android:text="A versatile full-zip that you can wear all day long and even..."/>
 
+        <!--
+            TODO Check out Google Pay's brand guidelines to discover all button types and styles:
+            https://developers.google.com/pay/api/android/guides/brand-guidelines#assets
+        -->
         <include
             android:id="@+id/googlePayButton"
             layout="@layout/buy_with_googlepay_button"

--- a/kotlin/app/src/main/res/values/dimens.xml
+++ b/kotlin/app/src/main/res/values/dimens.xml
@@ -22,7 +22,7 @@
     <dimen name="margin_xlarge">30dp</dimen>
 
     <dimen name="buy_button_width">300dp</dimen>
-    <dimen name="buy_button_height">48sp</dimen>
+    <dimen name="buy_button_height">48dp</dimen>
     <dimen name="buy_button_min_width">200dp</dimen>
 
 </resources>


### PR DESCRIPTION
Alternative implementation that does not require the `AutoResolveHelper` to complete the payment. This approach requires a similar developer effort and has the following advantages:
* Enables using the new [activity result APIs](https://developer.android.com/training/basics/intents/result#kotlin) and avoids the need to use deprecated code.
* Solves a long standing issue [preventing developers from using Google Pay inside of fragments](https://stackoverflow.com/questions/54020576/google-pay-autoresolvehelper-resolvetask-not-calling-onactivityresult-in-fragm).
* Adds flexibility to developers (eg.: enables the use of other async mechanisms, such as [coroutines on Kotlin](https://developers.google.com/android/guides/tasks#interoperability), the [recommended way to deal with async ops](https://developer.android.com/guide/background#recommended-immediate)).
* Allows us to remove a decent amount of logic and complexity needed to wrap the resolution intent its result, and send that back to the caller.
* Reduces complexity for developers: makes all calls homogeneous (calling `isReadyToPay` is similar to `loadPaymentData`).
